### PR TITLE
Use api.nvim_set_hl instead of cmd.hi

### DIFF
--- a/lua/multicursor-nvim/init.lua
+++ b/lua/multicursor-nvim/init.lua
@@ -3,10 +3,10 @@ local examples = require("multicursor-nvim.examples")
 
 table.unpack = table.unpack or unpack
 
-vim.cmd.hi("link", "MultiCursorCursor", "Cursor")
-vim.cmd.hi("link", "MultiCursorVisual", "Visual")
-vim.cmd.hi("link", "MultiCursorDisabledCursor", "Visual")
-vim.cmd.hi("link", "MultiCursorDisabledVisual", "Visual")
+vim.api.nvim_set_hl(0, "MultiCursorCursor", { link = "Cursor" })
+vim.api.nvim_set_hl(0, "MultiCursorVisual", { link = "Visual" })
+vim.api.nvim_set_hl(0, "MultiCursorDisabledCursor", { link = "Visual" })
+vim.api.nvim_set_hl(0, "MultiCursorDisabledVisual", { link = "Visual" })
 
 return {
     setup = core.setup,

--- a/readme.md
+++ b/readme.md
@@ -86,10 +86,10 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         vim.keymap.set("v", "<leader>T", function() mc.transposeCursors(-1) end)
 
         -- Customize how cursors look.
-        vim.cmd.hi("link", "MultiCursorCursor", "Cursor")
-        vim.cmd.hi("link", "MultiCursorVisual", "Visual")
-        vim.cmd.hi("link", "MultiCursorDisabledCursor", "Visual")
-        vim.cmd.hi("link", "MultiCursorDisabledVisual", "Visual")
+        vim.api.nvim_set_hl(0, "MultiCursorCursor", { link = "Cursor" })
+        vim.api.nvim_set_hl(0, "MultiCursorVisual", { link = "Visual" })
+        vim.api.nvim_set_hl(0, "MultiCursorDisabledCursor", { link = "Visual" })
+        vim.api.nvim_set_hl(0, "MultiCursorDisabledVisual", { link = "Visual" })
     end,
 }
 ```


### PR DESCRIPTION
This PR change the way highlights are set.

With `vim.cmd.hi`, this error was throwing when lazy loading:
```lua
Failed to run `config` for multicursor.nvim

...nvim/lazy/multicursor.nvim/lua/multicursor-nvim/init.lua:6: Vim:E414: Group has settings, highlight link ignored

# stacktrace:
  - /multicursor.nvim/lua/multicursor-nvim/init.lua:6
  - ~/.config/nvim/lua/jason/plugins/multicursor.lua:43 _in_ **config**
```

To repro using lazy.nvim:
```lua
return {
  'jake-stewart/multicursor.nvim',
  keys = {
    '<C-M-j>',
     --- ... keymaps
  },
  config = function()
    local mc = require 'multicursor-nvim'

    mc.setup()

    --- ... keymaps
  end,
}
```

Using `vim.api.nvim_set_hl` seems to fix this issue, I don't know if there's any drawbacks of using this method, the documentation says that the difference is that `nvim_set_hl` replaces entire hl definition instead of updating it, which should not cause problems since those hl are customs ones.

For consistency I also updated the readme.