### PR TITLE
fix(snippet): correctly cut snippet prefix

### DIFF
--- a/lua/multicursor-nvim/snippet-manager.lua
+++ b/lua/multicursor-nvim/snippet-manager.lua
@@ -39,7 +39,30 @@ function SnippetManager:performSnippet(wasFromSelectMode, typed, insertModePos)
     self._hasSnippet = false
     cursorManager:dirty()
     local reg = vim.fn.getreg(".")
-    reg = util.removeStartFromEnd(reg, self._snippetText)
+    local removedEndReg = util.removeStartFromEnd(reg, self._snippetText)
+    if reg == removedEndReg then
+        -- Note that label is not necessarily a prefix of
+        -- _snippetText, e.g. label is "sp" but _snippetText is
+        -- "fmt.Sprintf", that's why reg == removedEndReg here, in this case dot
+        -- register is "sp<BS><BS>sp" and what we want is "sp<BS><BS>".
+        --
+        -- For example, if user types `fo` and wants to expand "for range"
+        -- snippet, nvim-cmp will first fill dot register with two "<BS>" then
+        -- the label "for" which is emulated by `feedkeys()`, then use
+        -- `nvim_buf_set_text` to clear the "for", which is **not** recorded in
+        -- dot register, after that, it will eventually expand the snippet.
+        local last = #reg
+        for i = #reg, 3, -1 do
+            -- This sequence (128, 107, 98) represents "<BS>".
+            if reg:byte(i) == 98 and reg:byte(i - 1) == 107 and reg:byte(i - 2) == 128 then
+                last = i
+                break
+            end
+        end
+        reg = reg:sub(1, last)
+    else
+        reg = removedEndReg
+    end
 
     -- can't seem leave insert mode after using feedkeys mode "x!"
     -- which is required since we must stay in insert mode so that


### PR DESCRIPTION
Sometimes the `_snippetText` is not the same in dot register so `removeStartFromEnd` fails to cut it, this pr search the last `<BS>` which is an indicator of the start of a snippet prefix.

Before:


https://github.com/user-attachments/assets/09674d46-1d86-4a2c-ad7a-fc12a792ac8e



After:



https://github.com/user-attachments/assets/0cd0b964-e0ce-4d5f-af76-fd656855a2a8

