### PR TITLE
feat: match operator

### DIFF
--- a/lua/multicursor-nvim/init.lua
+++ b/lua/multicursor-nvim/init.lua
@@ -29,6 +29,7 @@ return {
     splitCursors = examples.splitCursors,
     alignCursors = examples.alignCursors,
     matchCursors = examples.matchCursors,
+    matchCursorsRange = examples.matchCursorsRange,
     transposeCursors = examples.transposeCursors,
     swapCursors = examples.swapCursors,
     addCursor = examples.addCursor,

--- a/lua/multicursor-nvim/operator.lua
+++ b/lua/multicursor-nvim/operator.lua
@@ -1,0 +1,55 @@
+local operator = {}
+
+operator.state = {
+	pattern = "",
+	visual = false,
+	motion = "",
+	wordBoundary = true,
+}
+
+local function cleanState()
+	operator.state = {
+		pattern = "",
+		visual = false,
+		motion = "",
+		wordBoundary = true,
+	}
+end
+
+local function getMarks()
+	local s = vim.api.nvim_buf_get_mark(0, "[")
+	local e = vim.api.nvim_buf_get_mark(0, "]")
+	return { startRow = s[1], startCol = s[2], endRow = e[1], endCol = e[2] }
+end
+
+---@param opts? { pattern: string, motion: string, visual: boolean, wordBoundary: boolean }
+function operator.operator(opts)
+	cleanState()
+	operator.state = vim.tbl_extend("force", operator.state, opts or {})
+	vim.o.operatorfunc = "v:lua.require'multicursor-nvim.operator'.operatorCallback"
+
+	if operator.state.pattern == "" then
+		vim.api.nvim_feedkeys(string.format("g@%s", operator.state.motion or ""), "mi", false)
+	else
+		vim.api.nvim_feedkeys(string.format("g@l"), "mi", false)
+	end
+end
+
+function operator.operatorCallback()
+	if operator.state.pattern == "" then
+		local marks = getMarks()
+		operator.state.pattern = string.format(
+			operator.state.wordBoundary and "\\<%s\\>" or "%s",
+			vim.api.nvim_buf_get_text(0, marks.startRow - 1, marks.startCol, marks.endRow - 1, marks.endCol + 1, {})[1]
+		)
+	end
+	vim.o.operatorfunc = "v:lua.require'multicursor-nvim.operator'.selectionOperatorCallback"
+	vim.api.nvim_feedkeys(string.format("g@"), "mi", false)
+end
+
+function operator.selectionOperatorCallback()
+	require("multicursor-nvim").matchCursorsRange(operator.state.pattern, getMarks(), operator.state.visual)
+	cleanState()
+end
+
+return operator


### PR DESCRIPTION
This is a minimal implementation of https://github.com/jake-stewart/multicursor.nvim/issues/79, user can define mappings like:
```lua
-- Press `<leader>mwap` will create a cursor in every match of `iw` in range `ap`
vim.keymap.set("n", "<leader>mw", function()
    require("multicursor-nvim.operator").operator({ motion = "iw" })
end)

-- Press `<leader>mwi"ap` will create a cursor in every match of string inside `i"` in range `ap`, also visual select them
vim.keymap.set("n", "<leader>mw", function()
    require("multicursor-nvim.operator").operator({ visual = true })
end)

-- press `mwi{` will select every \w, basically every char in a `{ a, b, c, d }`.
vim.keymap.set({ "n" }, "mw", function()
    require("multicursor-nvim.operator").operator({ pattern = [[\<\w]] })
end)
```

This plays very nice with flash treesitter label：

https://github.com/user-attachments/assets/5220ffe2-8f5f-45eb-be48-6c111dbd4b1a

