### PR TITLE
refactor(operator): support visual mode

### DIFF
--- a/doc/multicursor.txt
+++ b/doc/multicursor.txt
@@ -54,27 +54,40 @@ Continue reading for a guide of how to use the default config.
             local set = vim.keymap.set
 
             -- Add or skip cursor above/below the main cursor.
-            set({"n", "v"}, "<up>",
+            set({"n", "x"}, "<up>",
                 function() mc.lineAddCursor(-1) end)
-            set({"n", "v"}, "<down>",
+            set({"n", "x"}, "<down>",
                 function() mc.lineAddCursor(1) end)
-            set({"n", "v"}, "<leader><up>",
+            set({"n", "x"}, "<leader><up>",
                 function() mc.lineSkipCursor(-1) end)
-            set({"n", "v"}, "<leader><down>",
+            set({"n", "x"}, "<leader><down>",
                 function() mc.lineSkipCursor(1) end)
 
             -- Add or skip adding a new cursor by matching word/selection
-            set({"n", "v"}, "<leader>n",
+            set({"n", "x"}, "<leader>n",
                 function() mc.matchAddCursor(1) end)
-            set({"n", "v"}, "<leader>s",
+            set({"n", "x"}, "<leader>s",
                 function() mc.matchSkipCursor(1) end)
-            set({"n", "v"}, "<leader>N",
+            set({"n", "x"}, "<leader>N",
                 function() mc.matchAddCursor(-1) end)
-            set({"n", "v"}, "<leader>S",
+            set({"n", "x"}, "<leader>S",
                 function() mc.matchSkipCursor(-1) end)
 
+            -- In normal/visual mode, press `mwap` will create a cursor in every match of
+            -- the word captured by `iw` (or visually selected range) inside the bigger
+            -- range specified by `ap`. Useful to replace a word inside a function, e.g. mwif.
+            set({"n", "x"}, "mw", function()
+                mc.operator({ motion = "iw", visual = true })
+                -- Or you can pass a pattern, press `mwi{` will select every \w,
+                -- basically every char in a `{ a, b, c, d }`.
+                -- mc.operator({ pattern = [[\<\w]] })
+            end)
+
+            -- Press `mWi"ap` will create a cursor in every match of string captured by `i"` inside range `ap`.
+            set("n", "mW", mc.operator)
+
             -- Add all matches in the document
-            set({"n", "v"}, "<leader>A", mc.matchAllAddCursors)
+            set({"n", "x"}, "<leader>A", mc.matchAllAddCursors)
 
             -- You can also add cursors with any motion you prefer:
             -- set("n", "<right>", function()
@@ -85,20 +98,20 @@ Continue reading for a guide of how to use the default config.
             -- end)
 
             -- Rotate the main cursor.
-            set({"n", "v"}, "<left>", mc.nextCursor)
-            set({"n", "v"}, "<right>", mc.prevCursor)
+            set({"n", "x"}, "<left>", mc.nextCursor)
+            set({"n", "x"}, "<right>", mc.prevCursor)
 
             -- Delete the main cursor.
-            set({"n", "v"}, "<leader>x", mc.deleteCursor)
+            set({"n", "x"}, "<leader>x", mc.deleteCursor)
 
             -- Add and remove cursors with control + left click.
             set("n", "<c-leftmouse>", mc.handleMouse)
 
             -- Easy way to add and remove cursors using the main cursor.
-            set({"n", "v"}, "<c-q>", mc.toggleCursor)
+            set({"n", "x"}, "<c-q>", mc.toggleCursor)
 
             -- Clone every cursor and disable the originals.
-            set({"n", "v"}, "<leader><c-q>", mc.duplicateCursors)
+            set({"n", "x"}, "<leader><c-q>", mc.duplicateCursors)
 
             set("n", "<esc>", function()
                 if not mc.cursorsEnabled() then
@@ -117,30 +130,31 @@ Continue reading for a guide of how to use the default config.
             set("n", "<leader>a", mc.alignCursors)
 
             -- Split visual selections by regex.
-            set("v", "S", mc.splitCursors)
+            set("x", "S", mc.splitCursors)
 
             -- Append/insert for each line of visual selections.
-            set("v", "I", mc.insertVisual)
-            set("v", "A", mc.appendVisual)
+            set("x", "I", mc.insertVisual)
+            set("x", "A", mc.appendVisual)
 
             -- match new cursors within visual selections by regex.
-            set("v", "M", mc.matchCursors)
+            set("x", "M", mc.matchCursors)
 
             -- Rotate visual selection contents.
-            set("v", "<leader>t",
+            set("x", "<leader>t",
                 function() mc.transposeCursors(1) end)
-            set("v", "<leader>T",
+            set("x", "<leader>T",
                 function() mc.transposeCursors(-1) end)
 
             -- Jumplist support
-            set({"v", "n"}, "<c-i>", mc.jumpForward)
-            set({"v", "n"}, "<c-o>", mc.jumpBackward)
+            set({"x", "n"}, "<c-i>", mc.jumpForward)
+            set({"x", "n"}, "<c-o>", mc.jumpBackward)
 
             -- Customize how cursors look.
             local hl = vim.api.nvim_set_hl
             hl(0, "MultiCursorCursor", { link = "Cursor" })
             hl(0, "MultiCursorVisual", { link = "Visual" })
             hl(0, "MultiCursorSign", { link = "SignColumn"})
+            hl(0, "MultiCursorMatchPreview", { link = "Search" })
             hl(0, "MultiCursorDisabledCursor", { link = "Visual" })
             hl(0, "MultiCursorDisabledVisual", { link = "Visual" })
             hl(0, "MultiCursorDisabledSign", { link = "SignColumn"})
@@ -875,7 +889,7 @@ ctx:overlappedCursor()                      *multicursor-ctx-overlappedCursor*
 
     See also: ~
       • |multicursor-api-Cursor|
-    
+
 
 ctx:mainCursor()                                  *multicursor-ctx-mainCursor*
     Returns the main cursor.

--- a/lua/multicursor-nvim/examples.lua
+++ b/lua/multicursor-nvim/examples.lua
@@ -800,7 +800,7 @@ function examples.operator(opts)
             -- If called from visual mode, opts.pattern and opts.motion are ignored,
             -- we get pattern from previous visual selection.
             state.pattern = string.format(
-                state.wordBoundary and "\\<%s\\>" or "%s",
+                state.wordBoundary and "\\M\\<%s\\>" or "\\M%s",
                 getSelection(getRange(true), vMode)[1]
             )
         elseif state.pattern == "" then
@@ -811,6 +811,16 @@ function examples.operator(opts)
                 getSelection(getRange(false), opMode)[1]
             )
         end
+        local id = vim.fn.matchadd("MultiCursorMatchPreview", state.pattern, 2)
+        vim.schedule(function()
+            -- Press any key will clear the match.
+            vim.api.nvim_create_autocmd("SafeState", {
+                once = true,
+                callback = function()
+                    pcall(vim.fn.matchdelete, id)
+                end,
+            })
+        end)
         setOpfunc(function(mode)
             -- Second stage to get range, only '[ and '] markers make sense
             -- here, we get selection by mode (one of "char", "line", or "block").

--- a/lua/multicursor-nvim/init.lua
+++ b/lua/multicursor-nvim/init.lua
@@ -10,6 +10,7 @@ end
 setDefaultHighlight("MultiCursorCursor", "Cursor")
 setDefaultHighlight("MultiCursorVisual", "Visual")
 setDefaultHighlight("MultiCursorSign", "SignColumn")
+setDefaultHighlight("MultiCursorMatchPreview", "Search")
 setDefaultHighlight("MultiCursorDisabledCursor", "Visual")
 setDefaultHighlight("MultiCursorDisabledVisual", "Visual")
 setDefaultHighlight("MultiCursorDisabledSign", "SignColumn")

--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,7 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         hl(0, "MultiCursorCursor", { link = "Cursor" })
         hl(0, "MultiCursorVisual", { link = "Visual" })
         hl(0, "MultiCursorSign", { link = "SignColumn"})
+        hl(0, "MultiCursorMatchPreview", { link = "Search" })
         hl(0, "MultiCursorDisabledCursor", { link = "Visual" })
         hl(0, "MultiCursorDisabledVisual", { link = "Visual" })
         hl(0, "MultiCursorDisabledSign", { link = "SignColumn"})

--- a/readme.md
+++ b/readme.md
@@ -33,27 +33,40 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         local set = vim.keymap.set
 
         -- Add or skip cursor above/below the main cursor.
-        set({"n", "v"}, "<up>",
+        set({"n", "x"}, "<up>",
             function() mc.lineAddCursor(-1) end)
-        set({"n", "v"}, "<down>",
+        set({"n", "x"}, "<down>",
             function() mc.lineAddCursor(1) end)
-        set({"n", "v"}, "<leader><up>",
+        set({"n", "x"}, "<leader><up>",
             function() mc.lineSkipCursor(-1) end)
-        set({"n", "v"}, "<leader><down>",
+        set({"n", "x"}, "<leader><down>",
             function() mc.lineSkipCursor(1) end)
 
         -- Add or skip adding a new cursor by matching word/selection
-        set({"n", "v"}, "<leader>n",
+        set({"n", "x"}, "<leader>n",
             function() mc.matchAddCursor(1) end)
-        set({"n", "v"}, "<leader>s",
+        set({"n", "x"}, "<leader>s",
             function() mc.matchSkipCursor(1) end)
-        set({"n", "v"}, "<leader>N",
+        set({"n", "x"}, "<leader>N",
             function() mc.matchAddCursor(-1) end)
-        set({"n", "v"}, "<leader>S",
+        set({"n", "x"}, "<leader>S",
             function() mc.matchSkipCursor(-1) end)
 
+        -- In normal/visual mode, press `mwap` will create a cursor in every match of
+        -- the word captured by `iw` (or visually selected range) inside the bigger
+        -- range specified by `ap`. Useful to replace a word inside a function, e.g. mwif.
+        set({"n", "x"}, "mw", function()
+            mc.operator({ motion = "iw", visual = true })
+			-- Or you can pass a pattern, press `mwi{` will select every \w,
+		    -- basically every char in a `{ a, b, c, d }`.
+			-- mc.operator({ pattern = [[\<\w]] })
+        end)
+
+        -- Press `mWi"ap` will create a cursor in every match of string captured by `i"` inside range `ap`.
+        set("n", "mW", mc.operator)
+
         -- Add all matches in the document
-        set({"n", "v"}, "<leader>A", mc.matchAllAddCursors)
+        set({"n", "x"}, "<leader>A", mc.matchAllAddCursors)
 
         -- You can also add cursors with any motion you prefer:
         -- set("n", "<right>", function()
@@ -64,20 +77,20 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         -- end)
 
         -- Rotate the main cursor.
-        set({"n", "v"}, "<left>", mc.nextCursor)
-        set({"n", "v"}, "<right>", mc.prevCursor)
+        set({"n", "x"}, "<left>", mc.nextCursor)
+        set({"n", "x"}, "<right>", mc.prevCursor)
 
         -- Delete the main cursor.
-        set({"n", "v"}, "<leader>x", mc.deleteCursor)
+        set({"n", "x"}, "<leader>x", mc.deleteCursor)
 
         -- Add and remove cursors with control + left click.
         set("n", "<c-leftmouse>", mc.handleMouse)
 
         -- Easy way to add and remove cursors using the main cursor.
-        set({"n", "v"}, "<c-q>", mc.toggleCursor)
+        set({"n", "x"}, "<c-q>", mc.toggleCursor)
 
         -- Clone every cursor and disable the originals.
-        set({"n", "v"}, "<leader><c-q>", mc.duplicateCursors)
+        set({"n", "x"}, "<leader><c-q>", mc.duplicateCursors)
 
         set("n", "<esc>", function()
             if not mc.cursorsEnabled() then
@@ -96,24 +109,24 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         set("n", "<leader>a", mc.alignCursors)
 
         -- Split visual selections by regex.
-        set("v", "S", mc.splitCursors)
+        set("x", "S", mc.splitCursors)
 
         -- Append/insert for each line of visual selections.
-        set("v", "I", mc.insertVisual)
-        set("v", "A", mc.appendVisual)
+        set("x", "I", mc.insertVisual)
+        set("x", "A", mc.appendVisual)
 
         -- match new cursors within visual selections by regex.
-        set("v", "M", mc.matchCursors)
+        set("x", "M", mc.matchCursors)
 
         -- Rotate visual selection contents.
-        set("v", "<leader>t",
+        set("x", "<leader>t",
             function() mc.transposeCursors(1) end)
-        set("v", "<leader>T",
+        set("x", "<leader>T",
             function() mc.transposeCursors(-1) end)
 
         -- Jumplist support
-        set({"v", "n"}, "<c-i>", mc.jumpForward)
-        set({"v", "n"}, "<c-o>", mc.jumpBackward)
+        set({"x", "n"}, "<c-i>", mc.jumpForward)
+        set({"x", "n"}, "<c-o>", mc.jumpBackward)
 
         -- Customize how cursors look.
         local hl = vim.api.nvim_set_hl


### PR DESCRIPTION
This pr adds support for visual mode operator, the pattern will be chosen based
on visual selection, so `viwmwap` is the same as `mwap` or `mWiwap` (`mw/mW`
are added as examples for mapping in readme), but allows for more precise
control.

`getSelection()` is factored to behave differently (and correctly) depends on
the argument of opertorfunc `:h map-operator`, previously we always treat them
char wise, which is wrong in cases like `mwip` because we always lose the last
line's content.

Also: 
-  changes "v" to "x" in readme, as those mappings will have effect in
select mode.
 - add a new default hl group `MultiCursorMatchPreview` linked to
`Search`, after user choose the pattern (e.g. iw) it will match all word in
buffer, and after any keypress the match will be deleted.