### PR TITLE
feat: diagnosticMatchCursors/AddCursor/SkipCursor

### DIFF
--- a/doc/multicursor.txt
+++ b/doc/multicursor.txt
@@ -73,6 +73,23 @@ Continue reading for a guide of how to use the default config.
             set({"n", "x"}, "<leader>S",
                 function() mc.matchSkipCursor(-1) end)
 
+	    -- Add or skip adding a new cursor by matching diagnostics.
+	    set({"n", "x"}, "]D",
+	    function() mc.diagnosticAddCursor(1) end)
+	    set({"n", "x"}, "[D",
+	    function() mc.diagnosticAddCursor(-1) end)
+	    set({"n", "x"}, "<leader>d",
+		function() mc.diagnosticSkipCursor(1) end)
+	    set({"n", "x"}, "<leader>D",
+		function() mc.diagnosticSkipCursor(-1) end)
+
+	    -- In normal mode, `meap` match all diagnostics in range `ap`, this is the same
+	    -- as `vapme` in visual mode.
+	    set({"n", "x"}, "me", function()
+		-- The param is the same as `:h vim.diagnostic.GetOpts`.
+		mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR })
+	    end)
+
             -- In normal/visual mode, press `mwap` will create a cursor in every match of
             -- the word captured by `iw` (or visually selected range) inside the bigger
             -- range specified by `ap`. Useful to replace a word inside a function, e.g. mwif.
@@ -85,13 +102,6 @@ Continue reading for a guide of how to use the default config.
 
             -- Press `mWi"ap` will create a cursor in every match of string captured by `i"` inside range `ap`.
             set("n", "mW", mc.operator)
-
-	    -- In normal mode, `meap` match all diagnostics in range `ap`, this is the same
-	    -- as `vapme` in visual mode.
-	    set({"n", "x"}, "me", function()
-		-- The param is the same as `:h vim.diagnostic.GetOpts`.
-		mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR })
-	    end)
 
             -- Add all matches in the document
             set({"n", "x"}, "<leader>A", mc.matchAllAddCursors)

--- a/doc/multicursor.txt
+++ b/doc/multicursor.txt
@@ -86,6 +86,13 @@ Continue reading for a guide of how to use the default config.
             -- Press `mWi"ap` will create a cursor in every match of string captured by `i"` inside range `ap`.
             set("n", "mW", mc.operator)
 
+	    -- In normal mode, `meap` match all diagnostics in range `ap`, this is the same
+	    -- as `vapme` in visual mode.
+	    set({"n", "x"}, "me", function()
+		-- The param is the same as `:h vim.diagnostic.GetOpts`.
+		mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR})
+	    end)
+
             -- Add all matches in the document
             set({"n", "x"}, "<leader>A", mc.matchAllAddCursors)
 

--- a/doc/multicursor.txt
+++ b/doc/multicursor.txt
@@ -90,7 +90,7 @@ Continue reading for a guide of how to use the default config.
 	    -- as `vapme` in visual mode.
 	    set({"n", "x"}, "me", function()
 		-- The param is the same as `:h vim.diagnostic.GetOpts`.
-		mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR})
+		mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR })
 	    end)
 
             -- Add all matches in the document

--- a/lua/multicursor-nvim/examples.lua
+++ b/lua/multicursor-nvim/examples.lua
@@ -841,7 +841,7 @@ local function matchCursorsRange(pattern, range, selection, visual)
     end)
 end
 
-function examples.addCursorDiagnostics(opts)
+function examples.matchCursorDiagnostics(opts)
     local function is_visual(mode)
         return mode == "v" or mode == "V" or mode == "\22"
     end

--- a/lua/multicursor-nvim/init.lua
+++ b/lua/multicursor-nvim/init.lua
@@ -63,5 +63,7 @@ return {
     operator = examples.operator,
     sequenceIncrement = examples.sequenceIncrement,
     sequenceDecrement = examples.sequenceDecrement,
-    matchCursorDiagnostics = examples.matchCursorDiagnostics
+    diagnosticMatchCursors = examples.diagnosticMatchCursors,
+    diagnosticAddCursor = examples.diagnosticAddCursor,
+    diagnosticSkipCursor = examples.diagnosticSkipCursor,
 }

--- a/lua/multicursor-nvim/init.lua
+++ b/lua/multicursor-nvim/init.lua
@@ -62,5 +62,6 @@ return {
     deleteCursor = examples.deleteCursor,
     operator = examples.operator,
     sequenceIncrement = examples.sequenceIncrement,
-    sequenceDecrement = examples.sequenceDecrement
+    sequenceDecrement = examples.sequenceDecrement,
+    matchCursorDiagnostics = examples.matchCursorDiagnostics
 }

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         -- as `vapme` in visual mode.
         set({"n", "x"}, "me", function()
             -- The param is the same as `:h vim.diagnostic.GetOpts`.
-            mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR})
+            mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR })
         end)
 
         -- Add all matches in the document

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,13 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         -- Press `mWi"ap` will create a cursor in every match of string captured by `i"` inside range `ap`.
         set("n", "mW", mc.operator)
 
+        -- In normal mode, `meap` match all diagnostics in range `ap`, this is the same
+        -- as `vapme` in visual mode.
+        set({"n", "x"}, "me", function()
+            -- The param is the same as `:h vim.diagnostic.GetOpts`.
+            mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR})
+        end)
+
         -- Add all matches in the document
         set({"n", "x"}, "<leader>A", mc.matchAllAddCursors)
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,23 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
         set({"n", "x"}, "<leader>S",
             function() mc.matchSkipCursor(-1) end)
 
+        -- Add or skip adding a new cursor by matching diagnostics.
+        set({"n", "x"}, "]D",
+            function() mc.diagnosticAddCursor(1) end)
+        set({"n", "x"}, "[D",
+            function() mc.diagnosticAddCursor(-1) end)
+        set({"n", "x"}, "<leader>d",
+            function() mc.diagnosticSkipCursor(1) end)
+        set({"n", "x"}, "<leader>D",
+            function() mc.diagnosticSkipCursor(-1) end)
+
+        -- In normal mode, `meap` match all diagnostics in range `ap`, this is the same
+        -- as `vapme` in visual mode.
+        set({"n", "x"}, "me", function()
+            -- The param is the same as `:h vim.diagnostic.GetOpts`.
+            mc.diagnosticMatchCursors({ severity = vim.diagnostic.severity.ERROR })
+        end)
+
         -- In normal/visual mode, press `mwap` will create a cursor in every match of
         -- the word captured by `iw` (or visually selected range) inside the bigger
         -- range specified by `ap`. Useful to replace a word inside a function, e.g. mwif.
@@ -64,13 +81,6 @@ https://github.com/user-attachments/assets/a8c136dc-4786-447b-95c0-8e2a48f5776f
 
         -- Press `mWi"ap` will create a cursor in every match of string captured by `i"` inside range `ap`.
         set("n", "mW", mc.operator)
-
-        -- In normal mode, `meap` match all diagnostics in range `ap`, this is the same
-        -- as `vapme` in visual mode.
-        set({"n", "x"}, "me", function()
-            -- The param is the same as `:h vim.diagnostic.GetOpts`.
-            mc.matchCursorDiagnostics({ severity = vim.diagnostic.severity.ERROR })
-        end)
 
         -- Add all matches in the document
         set({"n", "x"}, "<leader>A", mc.matchAllAddCursors)


### PR DESCRIPTION
```lua
        keymap({ "n", "x" }, "me", function()
            mc.diagnosticMatchCursors({ severity = vim.diagnostic.severity.ERROR })
        end)
```
I'm trying to make it work in already multi cursor cases, that is, press `me$` should match diagnostics for not only main cursor's line, but also each cursor's line,  to achieve that, we need to know which range user just specified and replay that range to all cursors in setOpFunc, but I don't find a reliable way to get the range, e.g. `iw` or `ap` or `_`, hope you have some advice :)

Edit: I've made it that main cursor always use the correct range, other cursors are best effort. 