### PR TITLE
🐛 fix(feedkeys-manager): add 't' flag to keepjumps feedkeys

### DIFF
--- a/lua/multicursor-nvim/feedkeys-manager.lua
+++ b/lua/multicursor-nvim/feedkeys-manager.lua
@@ -45,17 +45,20 @@ function FeedkeysManager:setup()
 end
 
 function FeedkeysManager:keepjumpsFeedkeys(keys, mode)
+    mode = mode .. "t"
     keys = vim.fn.substitute(keys, "'", "'..\"'\"..'", "g")
     vim.cmd("keepjumps call feedkeys('" .. keys .. "', '" .. mode .. "')")
 end
 
 function FeedkeysManager:silentKeepjumpsFeedkeys(keys, mode)
+    mode = mode .. "t"
     keys = vim.fn.substitute(keys, "'", "'..\"'\"..'", "g")
     vim.cmd("silent keepjumps call feedkeys('"
         .. keys .. "', '" .. mode .. "')")
 end
 
 function FeedkeysManager:noAutocommandsKeepjumpsFeedkeys(keys, mode)
+    mode = mode .. "t"
     keys = vim.fn.substitute(keys, "'", "'..\"'\"..'", "g")
     vim.cmd("noautocmd keepjumps call feedkeys('"
         .. keys .. "', '" .. mode .. "')")


### PR DESCRIPTION
What changed:
- Added `mode = mode .. "t"` to the three keepjumps helpers in `lua/multicursor-nvim/feedkeys-manager.lua`:
  - keepjumpsFeedkeys
  - silentKeepjumpsFeedkeys
  - noAutocommandsKeepjumpsFeedkeys

Why:
- The `t` flag makes feedkeys treat the supplied keys as typed input, so they are processed through langmap and user remaps and are tracked by the feedkeys-manager wrapper.
- This fixes inconsistent behavior where the main cursor followed langmap but additional simulated cursors did not.
- Change is minimal and targeted to keepjumps variants to avoid global side effects.